### PR TITLE
Remove unused ftplib3 dependency since stdlib already covers FTP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyarrow>=14.0.1  # For parquet file support
 
 # File handling and compression
 requests>=2.31.0  # For downloading files
-ftplib3>=0.2.1   # For FTP operations
+#ftplib3>=0.2.1   # For FTP operations
 
 # Optional but recommended for improved performance
 multiprocess>=0.70.15  # For better multiprocessing support


### PR DESCRIPTION
FYI, pip install fails on ftplib3 (no matching distribution), and the stdlib’s ftplib already covers FTP. You can drop ftplib3 from requirements.txt.